### PR TITLE
Added user_config.h for local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pio
 .vscode/*
+src/user_config.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,6 @@ board = sipeed-longan-nano
 framework = gd32vf103-sdk
 build_unflags = -Os
 build_flags = -O2
-    -D MY_UID=0x17,0x13,0x31,0x19,0x23,0xEB
     ; -D USE_FLRC
 
 upload_protocol = dfu

--- a/src/config.h
+++ b/src/config.h
@@ -1,25 +1,13 @@
 #pragma once
 
+#include "user_config.h"
+
 // which board are we using
 
 // #define LONGAN_NANO
 // #define T_DISPLAY
 #define PCB_V1_0
 
-// some things are specific to each build
-
-// #define PROTOTYPE_V3
-// #define PROTOTYPE_V4
-#define PROTOTYPE_V5
-
-
-// TODO make dynamic
-
-#define COMPAT_LEVEL_1_0_0_RC3 (2)  // RC2 and RC3 are equivalent
-#define COMPAT_LEVEL_1_0_0_RC2 (2)
-#define COMPAT_LEVEL_DEV_16fbd1d011d060f56dcc9b3a33d9eead819cf440 (1)
-
-#define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0_RC3
 
 #ifdef ELRS_OG_COMPATIBILITY
     #define Regulatory_Domain_ISM_2400
@@ -27,12 +15,6 @@
     #define Regulatory_Domain_ISM_2400_NA
 #endif
 
-// TODO make this runtime dynamic
-// define the type of radio module being used 
-
-// #define RADIO_E28_12    // CAREFUL - this will break _20 and _27 if you use it by accident
-// #define RADIO_E28_20
-#define RADIO_E28_27    // Slightly careful - this goes 2 steps higher than E28_20. Probably won't break anything, but not ideal
 
 #ifdef RADIO_E28_12
 // E28-12 and both GNICERF modules can use the full output range
@@ -47,76 +29,13 @@
 #endif
 
 
-
 // how many switches do we have?
 // hybrid 8 currently deals with up to 8 switches, but if we only have 4 fitted we can save some time by
 // setting the lower value here
 #define MAX_SWITCHES    4
 
 
-// definitions for simpler gpio naming scheme
-
-enum ports {
-    PORTA,
-    PORTB,
-    PORTC
-};
-
-#define PA1  (PORTA << 16 | GPIO_PIN_1)
-#define PA2  (PORTA << 16 | GPIO_PIN_2)
-#define PA3  (PORTA << 16 | GPIO_PIN_3)
-#define PA4  (PORTA << 16 | GPIO_PIN_4)
-#define PA5  (PORTA << 16 | GPIO_PIN_5)
-#define PA6  (PORTA << 16 | GPIO_PIN_6)
-#define PA7  (PORTA << 16 | GPIO_PIN_7)
-#define PA8  (PORTA << 16 | GPIO_PIN_8)
-#define PA9  (PORTA << 16 | GPIO_PIN_9)
-#define PA10 (PORTA << 16 | GPIO_PIN_10)
-#define PA11 (PORTA << 16 | GPIO_PIN_11)
-#define PA12 (PORTA << 16 | GPIO_PIN_12)
-#define PA13 (PORTA << 16 | GPIO_PIN_13)
-#define PA14 (PORTA << 16 | GPIO_PIN_14)
-#define PA15 (PORTA << 16 | GPIO_PIN_15)
-
-#define PB1  (PORTB << 16 | GPIO_PIN_1)
-#define PB2  (PORTB << 16 | GPIO_PIN_2)
-#define PB3  (PORTB << 16 | GPIO_PIN_3)
-#define PB4  (PORTB << 16 | GPIO_PIN_4)
-#define PB5  (PORTB << 16 | GPIO_PIN_5)
-#define PB6  (PORTB << 16 | GPIO_PIN_6)
-#define PB7  (PORTB << 16 | GPIO_PIN_7)
-#define PB8  (PORTB << 16 | GPIO_PIN_8)
-#define PB9  (PORTB << 16 | GPIO_PIN_9)
-#define PB10 (PORTB << 16 | GPIO_PIN_10)
-#define PB11 (PORTB << 16 | GPIO_PIN_11)
-#define PB12 (PORTB << 16 | GPIO_PIN_12)
-#define PB13 (PORTB << 16 | GPIO_PIN_13)
-#define PB14 (PORTB << 16 | GPIO_PIN_14)
-#define PB15 (PORTB << 16 | GPIO_PIN_15)
-
-#define PC1  ((PORTC << 16) | GPIO_PIN_1)
-#define PC2  ((PORTC << 16) | GPIO_PIN_2)
-#define PC3  ((PORTC << 16) | GPIO_PIN_3)
-#define PC4  ((PORTC << 16) | GPIO_PIN_4)
-#define PC5  ((PORTC << 16) | GPIO_PIN_5)
-#define PC6  ((PORTC << 16) | GPIO_PIN_6)
-#define PC7  ((PORTC << 16) | GPIO_PIN_7)
-#define PC8  ((PORTC << 16) | GPIO_PIN_8)
-#define PC9  ((PORTC << 16) | GPIO_PIN_9)
-#define PC10 ((PORTC << 16) | GPIO_PIN_10)
-#define PC11 ((PORTC << 16) | GPIO_PIN_11)
-#define PC12 ((PORTC << 16) | GPIO_PIN_12)
-#define PC13 ((PORTC << 16) | GPIO_PIN_13)
-#define PC14 ((PORTC << 16) | GPIO_PIN_14)
-#define PC15 ((PORTC << 16) | GPIO_PIN_15)
-
-
-#define PIN(x) (x & 0xFFFF)
-
 // =====================
-
-
-
 
 #ifdef LONGAN_NANO
 
@@ -262,56 +181,7 @@ enum ports {
 // Buzzer
 #define GPIO_BUZZER PA4
 
-// Gimbal calibration values
-// These are for the Jumper hall gimbals, the sensors produce less than half the
-// output range compared to the FrSky gimbals. If we were using these long term
-// the ADCs would need to be reconfigured to give more resolution.
-// #define ADC_PITCH_REVERSED false
-// #define ADC_PITCH_MIN 744u
-// #define ADC_PITCH_CTR 1262u
-// #define ADC_PITCH_MAX 1824u
 
-// #define ADC_ROLL_REVERSED true
-// #define ADC_ROLL_MIN 702u
-// #define ADC_ROLL_CTR 1207u
-// #define ADC_ROLL_MAX 1809u
-
-// #define ADC_THROTTLE_REVERSED true
-// #define ADC_THROTTLE_MIN 742u
-// #define ADC_THROTTLE_MAX 1906u
-
-// #define ADC_YAW_REVERSED false
-// #define ADC_YAW_MIN 586u
-// #define ADC_YAW_CTR 1220u
-// #define ADC_YAW_MAX 1890u
-
-// frsky M7 in the V5 prototype
-
-// Define the mapping between ADC channels and AETR (aileron, elevator, throttle, rudder or roll, pitch, throttle, yaw)
-#define ADC_A_CH 3
-#define ADC_E_CH 2
-#define ADC_T_CH 0
-#define ADC_R_CH 1
-
-#define ADC_PITCH_REVERSED false
-#define ADC_PITCH_MIN 726u
-#define ADC_PITCH_CTR 2080u
-#define ADC_PITCH_MAX 3497u
-
-#define ADC_ROLL_REVERSED true
-#define ADC_ROLL_MIN 592u
-#define ADC_ROLL_CTR 2083u
-#define ADC_ROLL_MAX 3547u
-
-#define ADC_THROTTLE_REVERSED true
-#define ADC_THROTTLE_MIN 561u
-// throttle doesn't need a CTR value
-#define ADC_THROTTLE_MAX 3504u
-
-#define ADC_YAW_REVERSED false
-#define ADC_YAW_MIN 741u
-#define ADC_YAW_CTR 2081u
-#define ADC_YAW_MAX 3436u
 
 
 #else
@@ -329,12 +199,3 @@ enum ports {
 #define RADIO_DIO2_PORT GPIOB
 #define RADIO_DIO2_PIN GPIO_PIN_9
 
-
-// Pins with LEDS are being used for other things.
-
-// #define LED_PIN GPIO_PIN_13
-// #define LED_GPIO_PORT GPIOC
-// #define LED_GPIO_CLK RCU_GPIOC
-
-// #define GREEN_LED GPIO_PIN_1
-// #define BLUE_LED GPIO_PIN_2

--- a/src/config_constants.h
+++ b/src/config_constants.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// constants for the supported compatibility levels
+#define COMPAT_LEVEL_1_0_0_RC3 (2)  // RC2 and RC3 are equivalent
+#define COMPAT_LEVEL_1_0_0_RC2 (2)
+#define COMPAT_LEVEL_DEV_16fbd1d011d060f56dcc9b3a33d9eead819cf440 (1)
+
+
+// definitions for simpler gpio naming scheme
+
+enum ports {
+    PORTA,
+    PORTB,
+    PORTC
+};
+
+#define PA1  (PORTA << 16 | GPIO_PIN_1)
+#define PA2  (PORTA << 16 | GPIO_PIN_2)
+#define PA3  (PORTA << 16 | GPIO_PIN_3)
+#define PA4  (PORTA << 16 | GPIO_PIN_4)
+#define PA5  (PORTA << 16 | GPIO_PIN_5)
+#define PA6  (PORTA << 16 | GPIO_PIN_6)
+#define PA7  (PORTA << 16 | GPIO_PIN_7)
+#define PA8  (PORTA << 16 | GPIO_PIN_8)
+#define PA9  (PORTA << 16 | GPIO_PIN_9)
+#define PA10 (PORTA << 16 | GPIO_PIN_10)
+#define PA11 (PORTA << 16 | GPIO_PIN_11)
+#define PA12 (PORTA << 16 | GPIO_PIN_12)
+#define PA13 (PORTA << 16 | GPIO_PIN_13)
+#define PA14 (PORTA << 16 | GPIO_PIN_14)
+#define PA15 (PORTA << 16 | GPIO_PIN_15)
+
+#define PB1  (PORTB << 16 | GPIO_PIN_1)
+#define PB2  (PORTB << 16 | GPIO_PIN_2)
+#define PB3  (PORTB << 16 | GPIO_PIN_3)
+#define PB4  (PORTB << 16 | GPIO_PIN_4)
+#define PB5  (PORTB << 16 | GPIO_PIN_5)
+#define PB6  (PORTB << 16 | GPIO_PIN_6)
+#define PB7  (PORTB << 16 | GPIO_PIN_7)
+#define PB8  (PORTB << 16 | GPIO_PIN_8)
+#define PB9  (PORTB << 16 | GPIO_PIN_9)
+#define PB10 (PORTB << 16 | GPIO_PIN_10)
+#define PB11 (PORTB << 16 | GPIO_PIN_11)
+#define PB12 (PORTB << 16 | GPIO_PIN_12)
+#define PB13 (PORTB << 16 | GPIO_PIN_13)
+#define PB14 (PORTB << 16 | GPIO_PIN_14)
+#define PB15 (PORTB << 16 | GPIO_PIN_15)
+
+#define PC1  ((PORTC << 16) | GPIO_PIN_1)
+#define PC2  ((PORTC << 16) | GPIO_PIN_2)
+#define PC3  ((PORTC << 16) | GPIO_PIN_3)
+#define PC4  ((PORTC << 16) | GPIO_PIN_4)
+#define PC5  ((PORTC << 16) | GPIO_PIN_5)
+#define PC6  ((PORTC << 16) | GPIO_PIN_6)
+#define PC7  ((PORTC << 16) | GPIO_PIN_7)
+#define PC8  ((PORTC << 16) | GPIO_PIN_8)
+#define PC9  ((PORTC << 16) | GPIO_PIN_9)
+#define PC10 ((PORTC << 16) | GPIO_PIN_10)
+#define PC11 ((PORTC << 16) | GPIO_PIN_11)
+#define PC12 ((PORTC << 16) | GPIO_PIN_12)
+#define PC13 ((PORTC << 16) | GPIO_PIN_13)
+#define PC14 ((PORTC << 16) | GPIO_PIN_14)
+#define PC15 ((PORTC << 16) | GPIO_PIN_15)
+
+
+#define PIN(x) (x & 0xFFFF)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,8 +10,7 @@
 
 // Next:
 //    UI improvements
-//    Stick calibration
-//    Auto power limit when disarmed - or full dynamic power?
+//    Better stick calibration
 
 //    msp for vtx channel?
    // Info from BF msp.c:
@@ -25,11 +24,7 @@
 #define DEBUG_SUPPRESS
 
 // Uncomment to enable some debug output on the LCD
-// #define DEBUG_STATUS
-
-// uncomment for setting up the gimbals
-// #define STICK_CALIBRATION
-
+#define DEBUG_STATUS
 
 extern "C" {
 

--- a/src/user_config_template.txt
+++ b/src/user_config_template.txt
@@ -1,0 +1,68 @@
+#pragma once
+
+// This file holds user configurable settings. Copy it to user_config.h and it won't be
+// overwritten by future pulls from git.
+
+#include "config_constants.h"
+
+// ---------------------------------------------------------------
+
+// Binding code (as printed at the start of the build of the ELRS rx)
+// Dynamic binding and binding phrases are not supported.
+#define MY_UID 0,1,2,3,4,5
+
+
+// TODO make this runtime selectable from menus instead of having to rebuild and flash
+// Uncomment for setting up the gimbals
+// #define STICK_CALIBRATION
+
+
+// Compatibility with ELRS. If not defined, runs in experimental mode which needs modified RX and BF firmware.
+// Available constants for supported ELRS levels are in config_constants.h
+#define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0_RC3
+
+
+// TODO make this runtime dynamic
+// define the type of radio module being used 
+
+// #define RADIO_E28_12    // CAREFUL - this will break _20 and _27 if you use it by accident
+#define RADIO_E28_20
+// #define RADIO_E28_27    // Slightly careful - this goes 2 steps higher than E28_20. Probably won't break anything, but not ideal
+
+
+// Channel mapping and calibration
+
+// NB Every set of gimbals is different, you'll need to run the calibration mode and replace these values with
+// those for your gimbals!
+
+// For each channel, define the corresponding ADC index (as shown in the calibration display)
+// A = aeleron (roll)
+// E = elevator (pitch)
+// T = throttle
+// R = rudder (yaw)
+#define ADC_A_CH 3
+#define ADC_E_CH 2
+#define ADC_T_CH 0
+#define ADC_R_CH 1
+
+#define ADC_PITCH_REVERSED true
+#define ADC_PITCH_MIN 868u
+#define ADC_PITCH_CTR 2443u
+#define ADC_PITCH_MAX 3890u
+
+#define ADC_ROLL_REVERSED false
+#define ADC_ROLL_MIN 298u
+#define ADC_ROLL_CTR 1775u
+#define ADC_ROLL_MAX 3366u
+
+#define ADC_THROTTLE_REVERSED false
+#define ADC_THROTTLE_MIN 829u
+// throttle doesn't need a CTR value
+#define ADC_THROTTLE_MAX 3614u
+
+#define ADC_YAW_REVERSED true
+#define ADC_YAW_MIN 741u
+#define ADC_YAW_CTR 1676u
+#define ADC_YAW_MAX 3335u
+
+


### PR DESCRIPTION
This change moves the settings that are most likely to be changed for each
user/handset into user_config.h which is not under version control. An
example is provided as user_config_template.txt which the user should
copy to user_config.h and edit for their own preferences and hardware.
This way, when updating firmware by pulling from git the user config
won't get overwritten.