### PR TITLE
Initial code for dynamic power

### DIFF
--- a/lib/1AUDfilter/1AUDfilterInt.cpp
+++ b/lib/1AUDfilter/1AUDfilterInt.cpp
@@ -74,6 +74,17 @@ void DoublePT1filterInt::setK(const uint32_t newK)
     k = newK;
 }
 
+/** Calculate and set k
+ *  @param cuttoffFreq - frequency in Hz
+ *  @param sampleRate - the rate at which the filter will be updated in Hz
+ * 
+ */
+void DoublePT1filterInt::setCutoffHz(const float cuttoffFreq, const float sampleRate)
+{
+    const uint32_t k = cuttoffFreq * TWO_PI_SHIFTED / sampleRate;
+    this->setK(k);
+}
+
 uint32_t DoublePT1filterInt::getK()
 {
     return k;

--- a/lib/1AUDfilter/1AUDfilterInt.h
+++ b/lib/1AUDfilter/1AUDfilterInt.h
@@ -55,6 +55,7 @@ public:
     int32_t update(const int32_t x);
     uint32_t getK();
     void setK(const uint32_t newK);
+    void setCutoffHz(const float cuttoffFreq, const float sampleRate);
     int32_t getCurrent();
     void setInitial(const int32_t x);
 };

--- a/src/user_config_template.txt
+++ b/src/user_config_template.txt
@@ -14,11 +14,21 @@
 
 // TODO make this runtime selectable from menus instead of having to rebuild and flash
 // Uncomment for setting up the gimbals
+
 // #define STICK_CALIBRATION
+
+
+// Dynamic power automatically adjusts the power depending on the RSSI reported by telemetry
+// The power set in the handset menu becomes the max power when this is used. If telemetry
+// is disabled (or the quad goes out of telem range) then the max power is used, i.e. it 
+// should behave the same as it used to without dynamic power.
+
+// #define USE_DYNAMIC_POWER
 
 
 // Compatibility with ELRS. If not defined, runs in experimental mode which needs modified RX and BF firmware.
 // Available constants for supported ELRS levels are in config_constants.h
+
 #define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0_RC3
 
 


### PR DESCRIPTION
Introduces a filter for rssi dBm from telemetry packets and a pair of
thresholds for triggering power increase and decrease. Currently the
thresholds are hardcoded defines in main.cpp but could usefully be
based on the estimated sensitivity for the current packet mode and/or
be made user configurable.