### PR TITLE
Dynamic Power LQ and sensitivity

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,9 +70,9 @@ expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
 
     // Getting rxfail on indoor test quad, even though this is quicker than CR_4_5
     // {1, RATE_500HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_6, 2000,  TLM_RATIO_1_128,     8,          12},
-    {3, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000,  TLM_RATIO_1_64,      8,          12},
-    {4, RATE_150HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7, 7692,  TLM_RATIO_1_32,      4,          12},  // 130Hz
-    {5, RATE_50HZ,  SX1280_LORA_BW_0800, SX1280_LORA_SF8, SX1280_LORA_CR_LI_4_7,13333,  TLM_RATIO_1_32,      2,          12}}; //  75Hz
+    {3, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7,   4000,  TLM_RATIO_1_64,      8,          12},
+    {4, RATE_150HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7,   7692,  TLM_RATIO_1_32,      4,          12},  // 130Hz
+    {5, RATE_50HZ,  SX1280_LORA_BW_0800, SX1280_LORA_SF8, SX1280_LORA_CR_LI_4_7,  13333,  TLM_RATIO_1_32,      2,          12}}; //  75Hz
 
 expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 
@@ -85,12 +85,12 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 
     // long rx cycle times
     // TODO check the TOA values
-    {0, RATE_1KHZ,   -99,  675,  500,               1000,                       100,                       5000}, // no hw crc
-    {1, RATE_800HZ,  -99,  871,  500,               1000,                       100,                       5000},
-    {2, RATE_500HZ, -105, 1626,  500,               1000,                       100,                       5000},
-    {3, RATE_250HZ, -108, 3567, 1000,               1000,                       100,                       5000},
-    {4, RATE_150HZ, -112, 6660, 1000,               4000,                       100,                       5000},   // todo, see if the large RFmodeCycleAddtionalTime can be reduced
-    {5, RATE_50HZ,  -120,12059, 1000,               6000,                       133,                       5000}};
+    {0, RATE_1KHZ,   -99,  675,  500,               1000,                       100,                       1000},
+    {1, RATE_800HZ,  -99,  871,  500,               1000,                       100,                       1000},
+    {2, RATE_500HZ, -105, 1626,  500,               1000,                       100,                       1000},
+    {3, RATE_250HZ, -108, 3567, 1000,               1000,                       100,                       2000},
+    {4, RATE_150HZ, -112, 6660, 1000,               4000,                       100,                       2000},   // todo, see if the large RFmodeCycleAddtionalTime can be reduced
+    {5, RATE_50HZ,  -120,12059, 1000,               6000,                       133,                       4000}};
 
 #endif // ELRS_OG_COMPATIBILITY
 


### PR DESCRIPTION
Adjusts the power of the TX based on RSSI and LQ from telemetry packets. When using dynamic power the power level set on the radio is treated as the maximum to be used, and the actual power will be reduced from that according to the signal strength at the receiver.

Enable by adding #define USE_DYNAMIC_POWER to user_config.h

The thresholds and filter speed are set via #defines in main.cpp

DYN_POWER_INCREASE_MARGIN - relative to the rsSensitivity of the current packet rate mode
DYN_POWER_DECREASE_MARGIN - relative to the above threshold
DYN_POWER_LQ_THRESHOLD - LQ below which power will be gradually increased
DYN_POWER_LQ_PANIC_THRESHOLD - LQ below which power will be set directly to configured max
DYN_POWER_MISSED_TELEM_PACKET_THRESHOLD - The number of consecutive missed telemetry packets that will trigger a transition to the configured max power
DYN_POWER_RSSI_FILTER_CUTOFF_HZ - The filter cuttoff frequency for smoothing the RSSI values. Smaller values will produce a slower response when reducing power. Increases in power happen immediately.