### PR TITLE
Added COMPAT_LEVEL_1_0_0

### DIFF
--- a/src/config_constants.h
+++ b/src/config_constants.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // constants for the supported compatibility levels
+#define COMPAT_LEVEL_1_0_0     (2)  // V1.0.0 equivalent to RC3. Likely all RC >= 2 were compatible OTA
 #define COMPAT_LEVEL_1_0_0_RC3 (2)  // RC2 and RC3 are equivalent
 #define COMPAT_LEVEL_1_0_0_RC2 (2)
 #define COMPAT_LEVEL_DEV_16fbd1d011d060f56dcc9b3a33d9eead819cf440 (1)

--- a/src/user_config_template.txt
+++ b/src/user_config_template.txt
@@ -29,7 +29,7 @@
 // Compatibility with ELRS. If not defined, runs in experimental mode which needs modified RX and BF firmware.
 // Available constants for supported ELRS levels are in config_constants.h
 
-#define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0_RC3
+#define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0
 
 
 // TODO make this runtime dynamic


### PR DESCRIPTION
Tested with ELRS V1.0.0 using DIY_2400_RX_ESP8285_SX1280_via_UART.
No changes were required compared to the RC3 compatibility code, so this
is a documentation change only.