### PR TITLE
Send hires gimbal data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .pio
 .vscode/*
 src/user_config.h
+src/user_config_A1.txt
+src/user_config_V5.txt

--- a/lib/SX1280Driver/SX1280.cpp
+++ b/lib/SX1280Driver/SX1280.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include <stdio.h>
 #include <math.h>
 
+
 SX1280Hal hal;
 /////////////////////////////////////////////////////////////////
 SX1280Driver *SX1280Driver::instance = NULL;
@@ -87,10 +88,10 @@ void SX1280Driver::setupLora()
     this->ConfigModParams(currBW, currSF, currCR);                          //Step 5: Configure Modulation Params
     hal.WriteCommand(SX1280_RADIO_SET_AUTOFS, 0x01);                        //enable auto FS
     #ifdef USE_HARDWARE_CRC
-    this->SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_ON, SX1280_LORA_IQ_NORMAL);
+    this->SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, OTA_PACKET_LENGTH, SX1280_LORA_CRC_ON, SX1280_LORA_IQ_NORMAL);
     #else
     // TODO this ignores the UID based setup of IQ. Doesn't seem to matter, but seems like a problem waiting to happen
-    this->SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);
+    this->SetPacketParams(12, SX1280_LORA_PACKET_IMPLICIT, OTA_PACKET_LENGTH, SX1280_LORA_CRC_OFF, SX1280_LORA_IQ_NORMAL);
     #endif
 }
 
@@ -145,9 +146,9 @@ void ICACHE_RAM_ATTR SX1280Driver::Config(SX1280_RadioLoRaBandwidths_t bw, SX128
     this->SetMode(SX1280_MODE_STDBY_XOSC);
     ConfigModParams(bw, sf, cr);
     #ifdef USE_HARDWARE_CRC
-    SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_ON, iqMode);
+    SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, OTA_PACKET_LENGTH, SX1280_LORA_CRC_ON, iqMode);
     #else
-    SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, 8, SX1280_LORA_CRC_OFF, iqMode);
+    SetPacketParams(PreambleLength, SX1280_LORA_PACKET_IMPLICIT, OTA_PACKET_LENGTH, SX1280_LORA_CRC_OFF, iqMode);
     #endif
 
     SetFrequency(freq);
@@ -249,7 +250,7 @@ void SX1280Driver::SetPacketParamsFLRC()
     buf[2] = 0x00;  // SyncWordLength FLRC_SYNC_NOSYNC 0x00
     buf[3] = 0x00;  // SyncWordMatch RX_DISABLE_SYNC_WORD 0x00
     buf[4] = 0x00;  // PacketType PACKET_FIXED_LENGTH 0x00
-    buf[5] = 8;     // PayloadLength
+    buf[5] = OTA_PACKET_LENGTH;     // PayloadLength
     buf[6] = 0x10;  // CrcLength Docs are contradictory, this may be 2 bytes: CRC_1_BYTE 0x10
     buf[7] = 0x08;  // 0x08 Whitening must be disabled for FLRC
 
@@ -496,7 +497,7 @@ void SX1280Driver::TXnb(volatile uint8_t *data, uint8_t length)
 void SX1280Driver::readRXData()
 {
     uint8_t FIFOaddr = instance->GetRxBufferAddr();
-    hal.ReadBuffer(FIFOaddr, instance->RXdataBuffer, 8);
+    hal.ReadBuffer(FIFOaddr, instance->RXdataBuffer, OTA_PACKET_LENGTH);
 }
 
 void SX1280Driver::RXnb()

--- a/lib/SX1280Driver/SX1280.h
+++ b/lib/SX1280Driver/SX1280.h
@@ -3,8 +3,20 @@
 // #include "../../src/targets.h"
 #include "SX1280_Regs.h"
 #include "SX1280_hal.h"
+#include "../../src/user_config.h"
 
 #include <stdint.h>
+
+#if defined(USE_HIRES_DATA) && defined(ELRS_OG_COMPATIBILITY)
+#error "Can't use hires data in compatibility mode (yet)"
+#endif
+
+#if defined(USE_HIRES_DATA)
+#define OTA_PACKET_LENGTH 9
+#else
+#define OTA_PACKET_LENGTH 8
+#endif // USE_HIRES_DATA
+
 
 #define ICACHE_RAM_ATTR
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -56,6 +56,28 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
 
 #else // not ELRS_OG_COMPATIBILITY
 
+#ifdef USE_HIRES_DATA
+
+expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
+    // enum_rate,       bw,                 sf,                 cr,            interval, TLMinterval, FHSShopInterval, PreambleLen
+    {0, RATE_1KHZ,  SX1280_LORA_BW_1600, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_5, 1000,  TLM_RATIO_1_128,     8,          12}, // 714us
+    {1, RATE_500HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_6, 2000,  TLM_RATIO_1_128,     8,          12}, // 1586us, 79%
+    {2, RATE_250HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF6, SX1280_LORA_CR_LI_4_7, 4000,  TLM_RATIO_1_64,      8,          12}, // 3330us, 
+    {3, RATE_125HZ, SX1280_LORA_BW_0800, SX1280_LORA_SF7, SX1280_LORA_CR_LI_4_7, 8000,  TLM_RATIO_1_32,      4,          12}, // 
+
+};
+
+expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
+    //      rate    sens  TOA RFmodeCycleInterval RFmodeCycleAddtionalTime SyncPktIntervalDisconnected SyncPktIntervalConnected
+    {0, RATE_1KHZ,   -99,  714, 1000,               1000,                       100,                       5000},   // no hw crc
+    {1, RATE_500HZ, -105, 1586, 1000,               1000,                       100,                       5000},
+    {2, RATE_250HZ, -108, 3330, 1000,               1000,                       100,                       5000},
+    {3, RATE_125HZ, -112, 6187, 1000,               4000,                       100,                       5000},   // todo, see if the large RFmodeCycleAddtionalTime can be reduced
+
+};
+
+#else // not USE_HIRES_DATA
+
 expresslrs_mod_settings_s ExpressLRS_AirRateConfig[RATE_MAX] = {
     // enum_rate,       bw,                 sf,                 cr,            interval us, TLMinterval, FHSShopInterval, PreambleLen
     {0, RATE_1KHZ,  SX1280_LORA_BW_1600, SX1280_LORA_SF5, SX1280_LORA_CR_LI_4_5, 1000,  TLM_RATIO_1_128,     8,          12},   // 1000Hz
@@ -91,6 +113,8 @@ expresslrs_rf_pref_params_s ExpressLRS_AirRateRFperf[RATE_MAX] = {
     {3, RATE_250HZ, -108, 3567, 1000,               1000,                       100,                       2000},
     {4, RATE_150HZ, -112, 6660, 1000,               4000,                       100,                       2000},   // todo, see if the large RFmodeCycleAddtionalTime can be reduced
     {5, RATE_50HZ,  -120,12059, 1000,               6000,                       133,                       4000}};
+
+#endif // USE_HIRES_DATA
 
 #endif // ELRS_OG_COMPATIBILITY
 

--- a/src/common.h
+++ b/src/common.h
@@ -80,10 +80,9 @@ typedef enum
     RATE_250HZ = 3,
     RATE_200HZ = 4,
     RATE_150HZ = 5,
-    RATE_100HZ = 6,
-    RATE_50HZ = 7,
-    RATE_25HZ = 8,
-    RATE_4HZ = 9
+    RATE_125HZ = 6,
+    RATE_100HZ = 7,
+    RATE_50HZ  = 8,
 } expresslrs_RFrates_e; // Max value of 16 since only 4 bits have been assigned in the sync package.
 #endif // ELRS_OG_COMPATIBILITY
 
@@ -125,8 +124,15 @@ typedef struct expresslrs_mod_settings_s
 #define RATE_MAX 4  // actually the number of rates, so the max value is RATE_MAX-1
 #define RATE_DEFAULT 0
 #else
+
+#ifdef USE_HIRES_DATA
+#define RATE_MAX 4  // actually the number of rates, so the max value is RATE_MAX-1
+#define RATE_DEFAULT 1
+#else
 #define RATE_MAX 6  // actually the number of rates, so the max value is RATE_MAX-1
 #define RATE_DEFAULT 2
+#endif // USE_HIRES_DATA
+
 #endif // ELRS_OG_COMPATIBILITY
 
 typedef struct expresslrs_mod_settings_s

--- a/src/config_constants.h
+++ b/src/config_constants.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // constants for the supported compatibility levels
+#define COMPAT_LEVEL_1_0_0     (2)  // V1.0.0 equivalent to RC3. Likely all RC >= 2 were compatible OTA
 #define COMPAT_LEVEL_1_0_0_RC3 (2)  // RC2 and RC3 are equivalent
 #define COMPAT_LEVEL_1_0_0_RC2 (2)
 #define COMPAT_LEVEL_DEV_16fbd1d011d060f56dcc9b3a33d9eead819cf440 (1)

--- a/src/user_config_template.txt
+++ b/src/user_config_template.txt
@@ -31,6 +31,8 @@
 
 #define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0
 
+// Use high resolution gimbal data. Requires modified RX and Betaflight firmwares
+#define USE_HIRES_DATA
 
 // TODO make this runtime dynamic
 // define the type of radio module being used 

--- a/src/user_config_template.txt
+++ b/src/user_config_template.txt
@@ -29,7 +29,7 @@
 // Compatibility with ELRS. If not defined, runs in experimental mode which needs modified RX and BF firmware.
 // Available constants for supported ELRS levels are in config_constants.h
 
-#define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0_RC3
+#define ELRS_OG_COMPATIBILITY COMPAT_LEVEL_1_0_0
 
 
 // TODO make this runtime dynamic


### PR DESCRIPTION
Supports 12bit resolution for the 4 primary channels. Packet length increased
to 9 bytes, and new packet modes created to match
